### PR TITLE
feat: Add Standalone window.looker.table API & Excel Export Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ visualization: {
 For more details on installing custom visualizations in a project with `manifest.lkml` or globally via the Admin panel, refer to the Looker documentation on [developing custom visualizations using a project manifest](https://cloud.google.com/looker/docs/developing-custom-visualizations) or managing [Admin panel visualizations](https://cloud.google.com/looker/docs/admin-panel-visualizations).
 
 
+## Standalone Usage Outside Looker
+
+You can also use this visualization independently in any non-Looker web app by embedding the compiled `report_table.js` script and calling `window.looker.table()`.
+
+For complete integration instructions, method signatures, and payload data formats, see [standalone.md](standalone.md).
+
+
+
 ## Examples
 
 *Drag'n'drop columns for flat tables*

--- a/src/download_link.js
+++ b/src/download_link.js
@@ -31,24 +31,23 @@ export function getTableExcelDataUrl(targetElement) {
     return null;
   }
 
-  const copy_tbl = tbl.cloneNode(true);
   if (typeof window !== 'undefined' && typeof window.getComputedStyle === 'function') {
-    computedStyleToInlineStyle(copy_tbl, { recursive: true, properties: props });
+    computedStyleToInlineStyle(tbl, { recursive: true, properties: props });
   }
 
   const text =
     '<html xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:x="urn:schemas-microsoft-com:office:excel" xmlns="http://www.w3.org/TR/REC-html40">' +
     '<meta http-equiv=Content-Type content="text/html; charset=utf-8"><body>' +
     '<meta name=Generator content="Microsoft Excel 15">' +
-    copy_tbl.outerHTML +
+    tbl.outerHTML +
     '</body></html>';
 
   return "data:application/vnd.ms-excel," + encodeURIComponent(text);
 }
 
 // Alternative function that doesn't require setShowDownload callback
-export async function downloadTableAsExcel() {
-    const url = getTableExcelDataUrl();
+export async function downloadTableAsExcel(targetElement) {
+    const url = getTableExcelDataUrl(targetElement);
     if (!url) return;
     const text = decodeURIComponent(url.replace("data:application/vnd.ms-excel,", ""));
 

--- a/src/download_link.js
+++ b/src/download_link.js
@@ -1,41 +1,57 @@
+export function getTableExcelDataUrl(targetElement) {
+  const props = [
+    "font-size",
+    "color",
+    "text-align",
+    "border",
+    "vertical-align",
+    "font-style",
+    "font-weight",
+    "background-color",
+    "text-decoration",
+    "padding-left",
+    "border-bottom",
+    "border-top",
+    "border-left",
+    "border-right",
+  ];
+
+  let tbl = targetElement;
+  if (typeof tbl === 'string' && typeof document !== 'undefined') {
+    tbl = document.querySelector(tbl);
+  }
+  if (!tbl && typeof document !== 'undefined') {
+    tbl = document.getElementById("reportTable");
+  } else if (tbl && tbl.id !== "reportTable") {
+    tbl = tbl.querySelector("#reportTable") || tbl;
+  }
+
+  if (!tbl) {
+    console.error("Table element with id 'reportTable' not found");
+    return null;
+  }
+
+  const copy_tbl = tbl.cloneNode(true);
+  if (typeof window !== 'undefined' && typeof window.getComputedStyle === 'function') {
+    computedStyleToInlineStyle(copy_tbl, { recursive: true, properties: props });
+  }
+
+  const text =
+    '<html xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:x="urn:schemas-microsoft-com:office:excel" xmlns="http://www.w3.org/TR/REC-html40">' +
+    '<meta http-equiv=Content-Type content="text/html; charset=utf-8"><body>' +
+    '<meta name=Generator content="Microsoft Excel 15">' +
+    copy_tbl.outerHTML +
+    '</body></html>';
+
+  return "data:application/vnd.ms-excel," + encodeURIComponent(text);
+}
+
 // Alternative function that doesn't require setShowDownload callback
 export async function downloadTableAsExcel() {
-    const props = [
-      "font-size",
-      "color",
-      "text-align",
-      "border",
-      "vertical-align",
-      "font-style",
-      "font-weight",
-      "background-color",
-      "text-decoration",
-      "padding-left",
-      "border-bottom",
-      "border-top",
-      "border-left",
-      "border-right",
-    ];
-  
-    var tbl = document.getElementById("reportTable");
-  
-    if (!tbl) {
-      console.error("Table element with id 'reportTable' not found");
-      return;
-    }
-  
-    var copy_tbl = tbl.cloneNode(true);
-    computedStyleToInlineStyle(tbl, { recursive: true, properties: props });
-  
-    var text =
-      '<html xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:x="urn:schemas-microsoft-com:office:excel" xmlns="http://www.w3.org/TR/REC-html40">';
-    text +=
-      '<meta http-equiv=Content-Type content="text/html; charset=utf-8"><body>';
-    text += '<meta name=Generator content="Microsoft Excel 15">';
-    text += tbl.outerHTML;
-    text += "</body></html>";
-  
-    const url = "data:application/vnd.ms-excel," + encodeURIComponent(text);
+    const url = getTableExcelDataUrl();
+    if (!url) return;
+    const text = decodeURIComponent(url.replace("data:application/vnd.ms-excel,", ""));
+
   
     setTimeout(() => {
       const download = true;

--- a/src/report_table.js
+++ b/src/report_table.js
@@ -1,6 +1,6 @@
 import { ACTION_BUTTON_SIZE, ACTION_BUTTON_SPACING, INDEX_COLUMN, RIGHT_OFFSET_BASE } from './constants'
 import * as d3 from './d3loader'
-import { downloadTableAsExcel } from './download_link'
+import { downloadTableAsExcel, getTableExcelDataUrl } from './download_link'
 import { VisPluginTableModel } from './vis_table_plugin'
 
 
@@ -964,12 +964,11 @@ const buildReportTable = function(config, dataTable, updateColumnOrder, updateCo
   redraw()
 }
 
-if (typeof looker === 'undefined') {
-  global.looker = { plugins: { visualizations: { add: () => {} } } };
-}
-
-looker.plugins.visualizations.add({
+const visPlugin = {
   options: VisPluginTableModel.getCoreConfigOptions(),
+  trigger: function() {},
+  clearErrors: function() {},
+  addError: function(err) { console.error(err); },
   
   create: function(element, config) {
     this.svgContainer = d3.select(element)
@@ -993,21 +992,23 @@ looker.plugins.visualizations.add({
       return;
     }
 
+    const trigger = (typeof this.trigger === 'function' ? this.trigger : () => {}).bind(this);
+    const clearErrors = (typeof this.clearErrors === 'function' ? this.clearErrors : () => {}).bind(this);
+    const addError = (typeof this.addError === 'function' ? this.addError : (err) => console.error(err)).bind(this);
+
     const updateColumnOrder = newOrder => {
-      this.trigger('updateConfig', [{ columnOrder: newOrder }])
+      trigger('updateConfig', [{ columnOrder: newOrder }])
     }
     const updateConfig = newConfig => {
-      this.trigger('updateConfig', [newConfig])
+      trigger('updateConfig', [newConfig])
     }
-
-
 
     // ERROR HANDLING
 
-    this.clearErrors();
+    clearErrors();
 
-    if (queryResponse.fields.pivots.length > 2) {
-      this.addError({
+    if (queryResponse && queryResponse.fields && queryResponse.fields.pivots && queryResponse.fields.pivots.length > 2) {
+      addError({
         title: 'Max Two Pivots',
         message: 'This visualization accepts no more than 2 pivot fields.'
       });
@@ -1033,7 +1034,7 @@ looker.plugins.visualizations.add({
       .attr('id', 'visContainer')
 
     if (typeof config.columnOrder === 'undefined') {
-      this.trigger('updateConfig', [{ columnOrder: {} }])
+      trigger('updateConfig', [{ columnOrder: {} }])
     }
   
     // Dashboard-next fails to register config if no one has touched it
@@ -1055,13 +1056,85 @@ looker.plugins.visualizations.add({
 
     // console.log(config)
     var dataTable = new VisPluginTableModel(data, queryResponse, config)
-    this.trigger('registerOptions', dataTable.getConfigOptions())
+    trigger('registerOptions', dataTable.getConfigOptions())
     buildReportTable(config, dataTable, updateColumnOrder, updateConfig, element)
 
     // DEBUG OUTPUT AND DONE
     // console.log('dataTable', dataTable)
     // console.log('container', document.getElementById('visContainer').parentNode)
     
-    done();
+    if (typeof done === 'function') {
+      done();
+    }
   }
-})
+}
+
+if (typeof looker === 'undefined') {
+  global.looker = { plugins: { visualizations: { add: () => {} } } };
+}
+
+looker.plugins.visualizations.add(visPlugin);
+
+const rootGlobal = typeof window !== 'undefined' ? window : (typeof global !== 'undefined' ? global : {});
+rootGlobal.looker = rootGlobal.looker || {};
+rootGlobal.looker.table = function(targetElement, options = {}) {
+  let el = targetElement;
+  let opts = options;
+
+  if (targetElement && !targetElement.nodeType && typeof targetElement === 'object' && targetElement.element) {
+    el = targetElement.element;
+    opts = targetElement;
+  }
+
+  if (typeof el === 'string') {
+    el = document.querySelector(el);
+  }
+
+  if (!el) {
+    console.error('window.looker.table: Target element standard node or selector is required.');
+    return;
+  }
+
+  const data = opts.data || [];
+  const queryResponse = opts.queryResponse || opts;
+  const config = opts.config || {};
+  const details = opts.details || {};
+  const done = opts.done || (() => {});
+
+  const normalizedQueryResponse = Object.assign({}, queryResponse);
+  if (normalizedQueryResponse.fields) {
+    normalizedQueryResponse.fields = Object.assign({}, normalizedQueryResponse.fields);
+    normalizedQueryResponse.fields.dimension_like = normalizedQueryResponse.fields.dimension_like || normalizedQueryResponse.fields.dimensions || [];
+    normalizedQueryResponse.fields.measure_like = normalizedQueryResponse.fields.measure_like || [
+      ...(normalizedQueryResponse.fields.measures || []),
+      ...(normalizedQueryResponse.fields.table_calculations || [])
+    ];
+    normalizedQueryResponse.fields.pivots = normalizedQueryResponse.fields.pivots || [];
+  } else {
+    normalizedQueryResponse.fields = { dimension_like: [], measure_like: [], pivots: [] };
+  }
+
+  if (!el.hasChildNodes()) {
+    visPlugin.create(el, config);
+  }
+
+  visPlugin.updateAsync(data, el, config, normalizedQueryResponse, details, done);
+
+  return {
+    element: el,
+    asExcel: () => getTableExcelDataUrl(el),
+    downloadExcel: (filename) => {
+      const url = getTableExcelDataUrl(el);
+      if (!url) return null;
+      if (typeof window !== 'undefined' && window.document) {
+        const downloadRef = document.createElement("a");
+        downloadRef.href = url;
+        downloadRef.download = filename || `table-${new Date().toISOString().slice(0, 10)}.xls`;
+        document.body.appendChild(downloadRef);
+        downloadRef.click();
+        document.body.removeChild(downloadRef);
+      }
+      return url;
+    }
+  };
+};

--- a/src/report_table.js
+++ b/src/report_table.js
@@ -805,10 +805,11 @@ const buildReportTable = function(config, dataTable, updateColumnOrder, updateCo
         "box-shadow": "0 2px 4px rgba(0, 0, 0, 0.1)"
     }
 
+    const visContainerSelection = d3.select(element).select("#visContainer");
+
     // Add download button only if exposeDownloadLink is true
     if (config.exposeDownloadLink) {
-      const downloadButton = d3
-        .select("#visContainer")
+      const downloadButton = visContainerSelection
         .append("button")
         .attr("class", "vis-action-btn")
         .attr("id", "downloadButton")
@@ -818,14 +819,13 @@ const buildReportTable = function(config, dataTable, updateColumnOrder, updateCo
       downloadButton.style("top", "10px").style("right", RIGHT_OFFSET_BASE + "px")
 
       downloadButton.on("click", () => {
-          const el = d3.select('#downloadButton')
-          el.attr("class", "vis-action-btn loading")
+          downloadButton.attr("class", "vis-action-btn loading")
           // wait for the class to be registered
           setTimeout(async () => {
             try {
-              await downloadTableAsExcel();
+              await downloadTableAsExcel(element);
             } finally {
-              el.attr("class", "vis-action-btn")
+              downloadButton.attr("class", "vis-action-btn")
             }
           }, 250)
         });
@@ -852,7 +852,7 @@ const buildReportTable = function(config, dataTable, updateColumnOrder, updateCo
       const rightOffsetExpand = (config.exposeDownloadLink ? RIGHT_OFFSET_BASE + step : RIGHT_OFFSET_BASE) + "px";
       const rightOffsetCollapse = (config.exposeDownloadLink ? RIGHT_OFFSET_BASE + 2 * step : RIGHT_OFFSET_BASE + step) + "px";
 
-      const expandAllBtn = d3.select("#visContainer").append("button").attr("class", "vis-action-btn").attr("id", "expandAllBtn").attr("title", "Expand All")
+      const expandAllBtn = visContainerSelection.append("button").attr("class", "vis-action-btn").attr("id", "expandAllBtn").attr("title", "Expand All")
       Object.entries(baseActionBtnStyle).forEach(([k, v]) => expandAllBtn.style(k, v))
       expandAllBtn.style("top", "10px").style("right", rightOffsetExpand)
       expandAllBtn.on("click", () => {
@@ -866,7 +866,7 @@ const buildReportTable = function(config, dataTable, updateColumnOrder, updateCo
       });
       expandAllBtn.append("svg").attr("width", "16").attr("height", "16").attr("viewBox", "0 0 24 24").style("fill", "none").style("stroke", "#666").style("stroke-width", "2").style("stroke-linecap", "round").style("stroke-linejoin", "round").html('<polyline points="6 9 12 15 18 9"></polyline>');
 
-      const collapseAllBtn = d3.select("#visContainer").append("button").attr("class", "vis-action-btn").attr("id", "collapseAllBtn").attr("title", "Collapse All")
+      const collapseAllBtn = visContainerSelection.append("button").attr("class", "vis-action-btn").attr("id", "collapseAllBtn").attr("title", "Collapse All")
       Object.entries(baseActionBtnStyle).forEach(([k, v]) => collapseAllBtn.style(k, v))
       collapseAllBtn.style("top", "10px").style("right", rightOffsetCollapse)
       collapseAllBtn.on("click", () => {
@@ -889,7 +889,7 @@ const buildReportTable = function(config, dataTable, updateColumnOrder, updateCo
       const step = ACTION_BUTTON_SIZE + ACTION_BUTTON_SPACING;
       const rightOffsetClearSorts = (RIGHT_OFFSET_BASE + buttonCount * step) + "px";
 
-      const clearSortsBtn = d3.select("#visContainer").append("button").attr("class", "vis-action-btn").attr("id", "clearSortsBtn").attr("title", "Clear Client Sorts")
+      const clearSortsBtn = visContainerSelection.append("button").attr("class", "vis-action-btn").attr("id", "clearSortsBtn").attr("title", "Clear Client Sorts")
       Object.entries(baseActionBtnStyle).forEach(([k, v]) => clearSortsBtn.style(k, v))
       clearSortsBtn.style("top", "10px").style("right", rightOffsetClearSorts)
       clearSortsBtn.on("click", () => {
@@ -908,11 +908,11 @@ const buildReportTable = function(config, dataTable, updateColumnOrder, updateCo
 
     if (config.exposeDownloadLink || dataTable.hasSubtotals || (dataTable.clientSorts && dataTable.clientSorts.length > 0)) {
       // Add CSS hover styles
-      d3.select("#visContainer")
+      visContainerSelection
         .style("position", "relative")
         .style("cursor", "default")
         .on("mouseenter", () => {
-          d3.select("#visContainer").style("cursor", "default");
+          visContainerSelection.style("cursor", "default");
         });
 
       // Add CSS rules for hover and loading
@@ -1021,8 +1021,8 @@ const visPlugin = {
     // INITIALISE THE VIS
 
     try {
-      var elem = document.querySelector('#visContainer');
-      elem.parentNode.removeChild(elem);  
+      var elem = element.querySelector('#visContainer');
+      if (elem && elem.parentNode) elem.parentNode.removeChild(elem);  
     } catch(e) {}    
 
     element.style.position = 'relative';

--- a/src/vis_table_plugin.js
+++ b/src/vis_table_plugin.js
@@ -1079,6 +1079,7 @@ class VisPluginTableModel {
 
   buildTotals(queryResponse) {
     var totals_ = queryResponse.totals_data
+    if (!totals_) return;
     var totalsRow = new Row('total')
 
     this.columns.forEach(column => {

--- a/standalone.md
+++ b/standalone.md
@@ -1,0 +1,211 @@
+# Standalone Usage (Outside Looker)
+
+The Report Table visualization can be loaded and rendered independently in any standard web application (React, Vue, Angular, or Vanilla JS) without requiring Looker.
+
+---
+
+## 1. Quickstart
+
+Include the built `report_table.js` script tag or load it into your web application, then call `window.looker.table()`:
+
+```html
+<script src="path/to/report_table.js"></script>
+
+<div id="table-container" style="width: 100%; height: 600px;"></div>
+
+<script>
+  window.looker.table('#table-container', {
+    queryResponse: {
+      fields: {
+        dimensions: [{ name: 'category', label: 'Category' }],
+        measures: [{ name: 'sales', label: 'Total Sales' }],
+        pivots: []
+      }
+    },
+    data: [
+      {
+        category: { value: 'Apparel' },
+        sales: { value: 45000, rendered: '$45,000' }
+      }
+    ],
+    config: {
+      theme: 'contemporary',
+      bodyFontSize: 12,
+      headerFontSize: 12,
+      showHighlight: true
+    }
+  });
+</script>
+```
+
+---
+
+## 2. API Signatures & Instance Methods
+
+```javascript
+// Render table & obtain instance handle
+const tableInstance = window.looker.table('#table-container', options);
+
+// 1. Get Excel data URL string (data:application/vnd.ms-excel,...)
+const excelDataUrl = tableInstance.asExcel();
+
+// 2. Trigger browser download directly
+tableInstance.downloadExcel('financial-report.xls');
+```
+
+### Options Breakdown
+
+| Parameter | Type | Required | Description |
+| :--- | :--- | :--- | :--- |
+| `element` | `HTMLElement \| string` | Yes | Target DOM node or selector string (e.g. `'#my-table'`). |
+| `queryResponse` | `Object` | Yes | Column metadata definition schema (`dimensions`, `measures`, `pivots`). |
+| `data` | `Array<Object>` | Yes | Array of row objects. |
+| `config` | `Object` | No | Display & layout settings (`theme`, font sizes, subtotals, etc.). |
+| `details` | `Object` | No | Additional context details if needed. |
+| `done` | `Function` | No | Callback function triggered after rendering completes. |
+
+---
+
+## 3. Input Data Payload Formats
+
+### `queryResponse` Schema
+Defines the columns and field types:
+
+```json
+{
+  "fields": {
+    "dimensions": [
+      {
+        "name": "products.category",
+        "label": "Category",
+        "is_numeric": false
+      }
+    ],
+    "measures": [
+      {
+        "name": "orders.total_amount",
+        "label": "Total Sales",
+        "is_numeric": true
+      }
+    ],
+    "pivots": []
+  }
+}
+```
+
+### `data` Row Structures
+
+#### Flat Table (No Pivots)
+```json
+[
+  {
+    "products.category": { "value": "Apparel" },
+    "orders.total_amount": { "value": 45000, "rendered": "$45,000" }
+  },
+  {
+    "products.category": { "value": "Electronics" },
+    "orders.total_amount": { "value": 120000, "rendered": "$120,000" }
+  }
+]
+```
+
+#### Pivoted Table
+When `queryResponse.fields.pivots` contains pivot fields, measure values map to objects keyed by pivot names:
+
+```json
+[
+  {
+    "products.category": { "value": "Apparel" },
+    "orders.total_amount": {
+      "2025": { "value": 20000, "rendered": "$20,000" },
+      "2026": { "value": 25000, "rendered": "$25,000" }
+    }
+  }
+]
+```
+
+---
+
+## 4. Complete Configuration Options Reference (`config`)
+
+All available configuration options categorized by section:
+
+### Theme & Styling
+| Option | Type | Values / Default | Description |
+| :--- | :--- | :--- | :--- |
+| `theme` | `string` | `'traditional'` (default), `'looker'`, `'contemporary'`, `'custom'` | Table color theme |
+| `customTheme` | `string` | `""` (default) | URL to custom CSS file (used when `theme: "custom"`) |
+| `layout` | `string` | `'fixed'` (default), `'auto'` | Column width distribution layout |
+| `minWidthForIndexColumns` | `boolean` | `true` (default) | Automatic min-width on index/dimension columns |
+| `headerFontSize` | `number` | `12` (default) | Font size (px) for header cells |
+| `bodyFontSize` | `number` | `12` (default) | Font size (px) for body cells |
+| `showHighlight` | `boolean` | `true` (default) | Highlight row on hover |
+| `showTooltip` | `boolean` | `true` (default) | Show tooltip on hover |
+
+### Table & Layout
+| Option | Type | Values / Default | Description |
+| :--- | :--- | :--- | :--- |
+| `rowSubtotals` | `boolean` | `false` (default) | Calculate and show row subtotals |
+| `colSubtotals` | `boolean` | `false` (default) | Calculate and show column subtotals |
+| `collapsedSubtotals` | `string` | `""` | Comma-separated keys of subtotals to collapse |
+| `startFolded` | `boolean` | `false` (default) | Collapse all subtotals initially |
+| `genericLabelForSubtotals` | `boolean` | `false` (default) | Label all subtotal rows as `'Subtotal'` |
+| `spanRows` | `boolean` | `true` (default) | Merge duplicate dimension values vertically |
+| `spanCols` | `boolean` | `true` (default) | Merge duplicate header labels horizontally |
+| `transposeTable` | `boolean` | `false` (default) | Transpose rows and columns |
+| `sortColumnsBy` | `string` | `'pivots'` (default), `'measures'` | Column sorting order for pivoted tables |
+| `groupVarianceColumns` | `boolean` | `false` (default) | Group variance calculation columns |
+| `freezeFirstColumns` | `number` | `0` (default) | Number of left columns to freeze when scrolling horizontally |
+| `freezeTableHeaders` | `boolean` | `false` (default) | Freeze table header rows during vertical scroll |
+| `exposeDownloadLink` | `boolean` | `false` (default) | Render an Excel download icon button above table |
+
+### Field Labels & Formatting
+| Option | Type | Values / Default | Description |
+| :--- | :--- | :--- | :--- |
+| `indexColumn` | `boolean` | `false` (default) | Use last field only for dimension hierarchy |
+| `useViewName` | `boolean` | `false` (default) | Include view name prefix in column headers |
+| `useHeadings` | `boolean` | `false` (default) | Group fields under headings (from LookML tags) |
+| `useShortName` | `boolean` | `false` (default) | Use short names (from LookML tags) |
+| `useUnit` | `boolean` | `false` (default) | Display unit annotations (from LookML tags) |
+
+---
+
+## 5. Node.js Server-Side Usage (via JSDOM)
+
+Because the rendering engine uses DOM and D3 manipulation, run it inside a headless DOM environment (`jsdom`) when generating server-side HTML or PDFs in Node.js:
+
+```javascript
+const { JSDOM } = require('jsdom');
+
+// 1. Initialize headless DOM
+const dom = new JSDOM('<!DOCTYPE html><html><body><div id="table-container"></div></body></html>');
+global.window = dom.window;
+global.document = dom.window.document;
+global.navigator = dom.window.navigator;
+
+// 2. Import compiled bundle
+require('./dist/report_table.js'); // or require('./src/report_table.js')
+
+// 3. Render visualization into virtual DOM
+window.looker.table('#table-container', {
+  queryResponse: {
+    fields: {
+      dimensions: [{ name: 'category', label: 'Category' }],
+      measures: [{ name: 'sales', label: 'Total Sales' }]
+    }
+  },
+  data: [
+    {
+      category: { value: 'Apparel' },
+      sales: { value: 45000, rendered: '$45,000' }
+    }
+  ],
+  config: { theme: 'traditional' }
+});
+
+// 4. Extract generated HTML output
+const htmlOutput = dom.window.document.querySelector('#table-container').innerHTML;
+console.log(htmlOutput);
+```
+
+

--- a/standalone.md
+++ b/standalone.md
@@ -142,6 +142,23 @@ All available configuration options categorized by section:
 | `showHighlight` | `boolean` | `true` (default) | Highlight row on hover |
 | `showTooltip` | `boolean` | `true` (default) | Show tooltip on hover |
 
+#### Using External Custom CSS
+Setting `theme: 'custom'` and providing a URL in `customTheme` automatically injects a `<link rel="stylesheet">` into `<head>`:
+
+```javascript
+window.looker.table('#table-container', {
+  queryResponse,
+  data,
+  config: {
+    theme: 'custom',
+    customTheme: 'https://cdn.example.com/custom-theme.css'
+  }
+});
+```
+* **Browser Excel Export (`asExcel()`)**: Inlines the computed styles from the external CSS stylesheet onto every exported table cell (`<td>`, `<th>`).
+* **CORS Requirement**: External CSS URLs must serve Permissive CORS headers (`Access-Control-Allow-Origin: *`) when loaded cross-origin.
+
+
 ### Table & Layout
 | Option | Type | Values / Default | Description |
 | :--- | :--- | :--- | :--- |

--- a/tests/example_json_detail_lite_stream.json
+++ b/tests/example_json_detail_lite_stream.json
@@ -1,0 +1,1019 @@
+{
+  "added_params": null,
+  "aggregate_table_used_info": null,
+  "applied_column_limit": null,
+  "applied_filter_expression": null,
+  "applied_filters": {
+    "products.brand": {
+      "value": "-EMPTY",
+      "field": {
+        "align": "left",
+        "can_filter": true,
+        "can_time_filter": false,
+        "category": "dimension",
+        "default_filter_value": null,
+        "description": "",
+        "dimension_group": null,
+        "dynamic": false,
+        "enumerations": null,
+        "error": null,
+        "field_group_label": null,
+        "field_group_variant": "Brand",
+        "fill_style": null,
+        "filters": null,
+        "fiscal_month_offset": 0,
+        "has_allowed_values": false,
+        "hidden": false,
+        "is_filter": false,
+        "is_fiscal": false,
+        "is_numeric": false,
+        "is_timeframe": null,
+        "label": "Products Brand",
+        "label_from_parameter": null,
+        "label_short": "Brand",
+        "lookml_link": "/projects/thelook_ecomm/files/views%2F04_products.view.lkml?line=27",
+        "map_layer": null,
+        "measure": false,
+        "name": "products.brand",
+        "parameter": false,
+        "permanent": null,
+        "primary_key": false,
+        "project_name": "thelook_ecomm",
+        "requires_refresh_on_sort": false,
+        "scope": "products",
+        "sortable": true,
+        "source_file": "views/04_products.view.lkml",
+        "source_file_path": "thelook_ecomm/views/04_products.view.lkml",
+        "sql": "TRIM(${TABLE}.brand) ",
+        "sql_case": null,
+        "strict_value_format": false,
+        "suggest_dimension": "products.brand",
+        "suggest_explore": "order_items",
+        "suggestable": true,
+        "suggestions": null,
+        "tags": [],
+        "time_interval": null,
+        "type": "string",
+        "user_attribute_filter_types": ["string", "advanced_filter_string"],
+        "value_format": null,
+        "view": "products",
+        "view_label": "Products",
+        "week_start_day": "monday",
+        "times_used": 0,
+        "original_view": "products",
+        "sorted": null,
+        "synonyms": []
+      }
+    },
+    "order_items.created_week": {
+      "value": "NOT NULL",
+      "field": {
+        "align": "left",
+        "can_filter": true,
+        "can_time_filter": false,
+        "category": "dimension",
+        "default_filter_value": null,
+        "description": "Date and time the item was added to the order",
+        "dimension_group": "order_items.created",
+        "dynamic": false,
+        "enumerations": null,
+        "error": null,
+        "field_group_label": "Created Date",
+        "field_group_variant": "Week",
+        "fill_style": "range",
+        "filters": null,
+        "fiscal_month_offset": 0,
+        "has_allowed_values": false,
+        "hidden": false,
+        "is_filter": false,
+        "is_fiscal": false,
+        "is_numeric": false,
+        "is_timeframe": null,
+        "label": "Order Items Created Week",
+        "label_from_parameter": null,
+        "label_short": "Created Week",
+        "lookml_link": "/projects/thelook_ecomm/files/views%2F01_order_items.view.lkml?line=192",
+        "map_layer": null,
+        "measure": false,
+        "name": "order_items.created_week",
+        "parameter": false,
+        "permanent": null,
+        "primary_key": false,
+        "project_name": "thelook_ecomm",
+        "requires_refresh_on_sort": false,
+        "scope": "order_items",
+        "sortable": true,
+        "source_file": "views/01_order_items.view.lkml",
+        "source_file_path": "thelook_ecomm/views/01_order_items.view.lkml",
+        "sql": "${TABLE}.created_at ",
+        "sql_case": null,
+        "strict_value_format": false,
+        "suggest_dimension": "order_items.created_week",
+        "suggest_explore": "order_items",
+        "suggestable": false,
+        "suggestions": null,
+        "tags": [],
+        "time_interval": { "name": "week", "count": 1 },
+        "type": "date_week",
+        "user_attribute_filter_types": ["datetime", "advanced_filter_datetime"],
+        "value_format": null,
+        "view": "order_items",
+        "view_label": "Order Items",
+        "week_start_day": "monday",
+        "times_used": 0,
+        "original_view": "order_items",
+        "sorted": null,
+        "synonyms": []
+      }
+    }
+  },
+  "applied_limit": null,
+  "cache_key": null,
+  "cached_derived_tables": null,
+  "can_see_sql": null,
+  "column_truncated": null,
+  "description": null,
+  "errors": null,
+  "expired": null,
+  "explore": {
+    "description": null,
+    "label": "(1) Orders, Items and Users",
+    "name": "order_items"
+  },
+  "fields": {
+    "dimensions": [
+      {
+        "align": "left",
+        "can_filter": true,
+        "can_time_filter": false,
+        "category": "dimension",
+        "default_filter_value": null,
+        "description": "Date and time the item was added to the order",
+        "dimension_group": "order_items.created",
+        "dynamic": false,
+        "enumerations": null,
+        "error": null,
+        "field_group_label": "Created Date",
+        "field_group_variant": "Week",
+        "fill_style": "range",
+        "filters": null,
+        "fiscal_month_offset": 0,
+        "has_allowed_values": false,
+        "hidden": false,
+        "is_filter": false,
+        "is_fiscal": false,
+        "is_numeric": false,
+        "is_timeframe": null,
+        "label": "Order Items Created Week",
+        "label_from_parameter": null,
+        "label_short": "Created Week",
+        "lookml_link": "/projects/thelook_ecomm/files/views%2F01_order_items.view.lkml?line=192",
+        "map_layer": null,
+        "measure": false,
+        "name": "order_items.created_week",
+        "parameter": false,
+        "permanent": null,
+        "primary_key": false,
+        "project_name": "thelook_ecomm",
+        "requires_refresh_on_sort": false,
+        "scope": "order_items",
+        "sortable": true,
+        "source_file": "views/01_order_items.view.lkml",
+        "source_file_path": "thelook_ecomm/views/01_order_items.view.lkml",
+        "sql": "${TABLE}.created_at ",
+        "sql_case": null,
+        "strict_value_format": false,
+        "suggest_dimension": "order_items.created_week",
+        "suggest_explore": "order_items",
+        "suggestable": false,
+        "suggestions": null,
+        "tags": [],
+        "time_interval": { "name": "week", "count": 1 },
+        "type": "date_week",
+        "user_attribute_filter_types": ["datetime", "advanced_filter_datetime"],
+        "value_format": null,
+        "view": "order_items",
+        "view_label": "Order Items",
+        "week_start_day": "monday",
+        "times_used": 0,
+        "original_view": "order_items",
+        "sorted": null,
+        "synonyms": []
+      }
+    ],
+    "measures": [
+      {
+        "align": "right",
+        "can_filter": true,
+        "can_time_filter": false,
+        "category": "measure",
+        "default_filter_value": null,
+        "description": "Total revenue from order items",
+        "dimension_group": null,
+        "dynamic": false,
+        "enumerations": null,
+        "error": null,
+        "field_group_label": null,
+        "field_group_variant": "Total Sale Price",
+        "fill_style": null,
+        "filters": null,
+        "fiscal_month_offset": 0,
+        "has_allowed_values": false,
+        "hidden": false,
+        "is_filter": false,
+        "is_fiscal": false,
+        "is_numeric": true,
+        "is_timeframe": null,
+        "label": "Order Items Total Sale Price",
+        "label_from_parameter": null,
+        "label_short": "Total Sale Price",
+        "lookml_link": "/projects/thelook_ecomm/files/views%2F01_order_items.view.lkml?line=323",
+        "map_layer": null,
+        "measure": true,
+        "name": "order_items.total_sale_price",
+        "parameter": false,
+        "permanent": null,
+        "primary_key": false,
+        "project_name": "thelook_ecomm",
+        "requires_refresh_on_sort": false,
+        "scope": "order_items",
+        "sortable": true,
+        "source_file": "views/01_order_items.view.lkml",
+        "source_file_path": "thelook_ecomm/views/01_order_items.view.lkml",
+        "sql": "${sale_price} ",
+        "sql_case": null,
+        "strict_value_format": false,
+        "suggest_dimension": "order_items.total_sale_price",
+        "suggest_explore": "order_items",
+        "suggestable": false,
+        "suggestions": null,
+        "tags": [],
+        "time_interval": null,
+        "type": "sum",
+        "user_attribute_filter_types": ["number", "advanced_filter_number"],
+        "value_format": "$#,##0.00",
+        "view": "order_items",
+        "view_label": "Order Items",
+        "week_start_day": "monday",
+        "times_used": 0,
+        "original_view": "order_items",
+        "sorted": null,
+        "synonyms": []
+      }
+    ],
+    "pivots": [],
+    "table_calculations": []
+  },
+  "fill_fields": [],
+  "from_cache": null,
+  "has_row_totals": false,
+  "has_totals": false,
+  "name": null,
+  "number_format": null,
+  "null_sort_treatment": null,
+  "pivot_hack_undone": null,
+  "ran_at": null,
+  "runtime": "",
+  "sql": "-- Did not use order_items::rollup__products_brand__products_category__products_item_name; it does not include the following fields in the query: order_items.created_week, order_items.total_sale_price\nSELECT\n    (FORMAT_TIMESTAMP('%F', TIMESTAMP_TRUNC(order_items.created_at , WEEK(MONDAY)))) AS order_items_created_week,\n    COALESCE(SUM(order_items.sale_price), 0) AS order_items_total_sale_price\nFROM looker-private-demo.ecomm.order_items  AS order_items\nFULL OUTER JOIN looker-private-demo.ecomm.inventory_items  AS inventory_items ON inventory_items.id = order_items.inventory_item_id\nLEFT JOIN looker-private-demo.ecomm.products  AS products ON products.id = inventory_items.product_id\nWHERE ((( order_items.created_at  ) IS NOT NULL)) AND LENGTH(TRIM(products.brand) ) <> 0 AND (TRIM(products.brand) ) IS NOT NULL\nGROUP BY\n    1",
+  "sql_explain": null,
+  "sql_error": null,
+  "supports_pivot_in_db": null,
+  "timezone": "UTC",
+  "totals_data": null,
+  "truncated": null,
+  "warnings": null,
+  "data": [
+    {
+      "order_items.created_week": { "value": "2022-12-26" },
+      "order_items.total_sale_price": { "value": 2499.45001411438 }
+    },
+    {
+      "order_items.created_week": { "value": "2023-01-02" },
+      "order_items.total_sale_price": { "value": 9789.130036830902 }
+    },
+    {
+      "order_items.created_week": { "value": "2023-01-09" },
+      "order_items.total_sale_price": { "value": 10780.460053920746 }
+    },
+    {
+      "order_items.created_week": { "value": "2023-01-16" },
+      "order_items.total_sale_price": { "value": 11725.980043888092 }
+    },
+    {
+      "order_items.created_week": { "value": "2023-01-23" },
+      "order_items.total_sale_price": { "value": 11087.460058450699 }
+    },
+    {
+      "order_items.created_week": { "value": "2023-01-30" },
+      "order_items.total_sale_price": { "value": 15306.880026578903 }
+    },
+    {
+      "order_items.created_week": { "value": "2023-02-06" },
+      "order_items.total_sale_price": { "value": 12724.380078792572 }
+    },
+    {
+      "order_items.created_week": { "value": "2023-02-13" },
+      "order_items.total_sale_price": { "value": 15837.320029258728 }
+    },
+    {
+      "order_items.created_week": { "value": "2023-02-20" },
+      "order_items.total_sale_price": { "value": 14582.76007258892 }
+    },
+    {
+      "order_items.created_week": { "value": "2023-02-27" },
+      "order_items.total_sale_price": { "value": 14843.110026836395 }
+    },
+    {
+      "order_items.created_week": { "value": "2023-03-06" },
+      "order_items.total_sale_price": { "value": 15652.090067863464 }
+    },
+    {
+      "order_items.created_week": { "value": "2023-03-13" },
+      "order_items.total_sale_price": { "value": 15668.380042433739 }
+    },
+    {
+      "order_items.created_week": { "value": "2023-03-20" },
+      "order_items.total_sale_price": { "value": 15281.620066165924 }
+    },
+    {
+      "order_items.created_week": { "value": "2023-03-27" },
+      "order_items.total_sale_price": { "value": 19217.220074653625 }
+    },
+    {
+      "order_items.created_week": { "value": "2023-04-03" },
+      "order_items.total_sale_price": { "value": 21229.45011138916 }
+    },
+    {
+      "order_items.created_week": { "value": "2023-04-10" },
+      "order_items.total_sale_price": { "value": 21112.6100628376 }
+    },
+    {
+      "order_items.created_week": { "value": "2023-04-17" },
+      "order_items.total_sale_price": { "value": 17069.580077171326 }
+    },
+    {
+      "order_items.created_week": { "value": "2023-04-24" },
+      "order_items.total_sale_price": { "value": 20961.73006761074 }
+    },
+    {
+      "order_items.created_week": { "value": "2023-05-01" },
+      "order_items.total_sale_price": { "value": 18019.840091705322 }
+    },
+    {
+      "order_items.created_week": { "value": "2023-05-08" },
+      "order_items.total_sale_price": { "value": 19127.40006327629 }
+    },
+    {
+      "order_items.created_week": { "value": "2023-05-15" },
+      "order_items.total_sale_price": { "value": 19598.860041856766 }
+    },
+    {
+      "order_items.created_week": { "value": "2023-05-22" },
+      "order_items.total_sale_price": { "value": 22564.06006836891 }
+    },
+    {
+      "order_items.created_week": { "value": "2023-05-29" },
+      "order_items.total_sale_price": { "value": 19116.26007246971 }
+    },
+    {
+      "order_items.created_week": { "value": "2023-06-05" },
+      "order_items.total_sale_price": { "value": 21362.37011909485 }
+    },
+    {
+      "order_items.created_week": { "value": "2023-06-12" },
+      "order_items.total_sale_price": { "value": 21610.700067043304 }
+    },
+    {
+      "order_items.created_week": { "value": "2023-06-19" },
+      "order_items.total_sale_price": { "value": 23432.3500944376 }
+    },
+    {
+      "order_items.created_week": { "value": "2023-06-26" },
+      "order_items.total_sale_price": { "value": 21985.620068073273 }
+    },
+    {
+      "order_items.created_week": { "value": "2023-07-03" },
+      "order_items.total_sale_price": { "value": 20847.690066337585 }
+    },
+    {
+      "order_items.created_week": { "value": "2023-07-10" },
+      "order_items.total_sale_price": { "value": 21430.62007498741 }
+    },
+    {
+      "order_items.created_week": { "value": "2023-07-17" },
+      "order_items.total_sale_price": { "value": 22337.480093479156 }
+    },
+    {
+      "order_items.created_week": { "value": "2023-07-24" },
+      "order_items.total_sale_price": { "value": 25692.080075740814 }
+    },
+    {
+      "order_items.created_week": { "value": "2023-07-31" },
+      "order_items.total_sale_price": { "value": 28150.790120601654 }
+    },
+    {
+      "order_items.created_week": { "value": "2023-08-07" },
+      "order_items.total_sale_price": { "value": 25387.44006705284 }
+    },
+    {
+      "order_items.created_week": { "value": "2023-08-14" },
+      "order_items.total_sale_price": { "value": 28723.010097026825 }
+    },
+    {
+      "order_items.created_week": { "value": "2023-08-21" },
+      "order_items.total_sale_price": { "value": 27995.070106744766 }
+    },
+    {
+      "order_items.created_week": { "value": "2023-08-28" },
+      "order_items.total_sale_price": { "value": 28666.300156712532 }
+    },
+    {
+      "order_items.created_week": { "value": "2023-09-04" },
+      "order_items.total_sale_price": { "value": 31280.610099315643 }
+    },
+    {
+      "order_items.created_week": { "value": "2023-09-11" },
+      "order_items.total_sale_price": { "value": 30419.5901157856 }
+    },
+    {
+      "order_items.created_week": { "value": "2023-09-18" },
+      "order_items.total_sale_price": { "value": 31559.820126652718 }
+    },
+    {
+      "order_items.created_week": { "value": "2023-09-25" },
+      "order_items.total_sale_price": { "value": 32711.610134363174 }
+    },
+    {
+      "order_items.created_week": { "value": "2023-10-02" },
+      "order_items.total_sale_price": { "value": 38538.170102357864 }
+    },
+    {
+      "order_items.created_week": { "value": "2023-10-09" },
+      "order_items.total_sale_price": { "value": 33652.13008570671 }
+    },
+    {
+      "order_items.created_week": { "value": "2023-10-16" },
+      "order_items.total_sale_price": { "value": 36744.290127038956 }
+    },
+    {
+      "order_items.created_week": { "value": "2023-10-23" },
+      "order_items.total_sale_price": { "value": 33006.72011399269 }
+    },
+    {
+      "order_items.created_week": { "value": "2023-10-30" },
+      "order_items.total_sale_price": { "value": 35282.590158462524 }
+    },
+    {
+      "order_items.created_week": { "value": "2023-11-06" },
+      "order_items.total_sale_price": { "value": 39278.35011386871 }
+    },
+    {
+      "order_items.created_week": { "value": "2023-11-13" },
+      "order_items.total_sale_price": { "value": 38275.85014438629 }
+    },
+    {
+      "order_items.created_week": { "value": "2023-11-20" },
+      "order_items.total_sale_price": { "value": 40111.790105342865 }
+    },
+    {
+      "order_items.created_week": { "value": "2023-11-27" },
+      "order_items.total_sale_price": { "value": 39214.100098490715 }
+    },
+    {
+      "order_items.created_week": { "value": "2023-12-04" },
+      "order_items.total_sale_price": { "value": 39312.600167512894 }
+    },
+    {
+      "order_items.created_week": { "value": "2023-12-11" },
+      "order_items.total_sale_price": { "value": 43987.42017579079 }
+    },
+    {
+      "order_items.created_week": { "value": "2023-12-18" },
+      "order_items.total_sale_price": { "value": 40471.290175914764 }
+    },
+    {
+      "order_items.created_week": { "value": "2023-12-25" },
+      "order_items.total_sale_price": { "value": 42547.1601395607 }
+    },
+    {
+      "order_items.created_week": { "value": "2024-01-01" },
+      "order_items.total_sale_price": { "value": 39199.050141334534 }
+    },
+    {
+      "order_items.created_week": { "value": "2024-01-08" },
+      "order_items.total_sale_price": { "value": 38719.69021320343 }
+    },
+    {
+      "order_items.created_week": { "value": "2024-01-15" },
+      "order_items.total_sale_price": { "value": 35448.900163173676 }
+    },
+    {
+      "order_items.created_week": { "value": "2024-01-22" },
+      "order_items.total_sale_price": { "value": 39067.41014242172 }
+    },
+    {
+      "order_items.created_week": { "value": "2024-01-29" },
+      "order_items.total_sale_price": { "value": 40091.94018244743 }
+    },
+    {
+      "order_items.created_week": { "value": "2024-02-05" },
+      "order_items.total_sale_price": { "value": 40801.30013239384 }
+    },
+    {
+      "order_items.created_week": { "value": "2024-02-12" },
+      "order_items.total_sale_price": { "value": 41111.23012816906 }
+    },
+    {
+      "order_items.created_week": { "value": "2024-02-19" },
+      "order_items.total_sale_price": { "value": 42019.87016057968 }
+    },
+    {
+      "order_items.created_week": { "value": "2024-02-26" },
+      "order_items.total_sale_price": { "value": 44029.62013065815 }
+    },
+    {
+      "order_items.created_week": { "value": "2024-03-04" },
+      "order_items.total_sale_price": { "value": 40305.23014378548 }
+    },
+    {
+      "order_items.created_week": { "value": "2024-03-11" },
+      "order_items.total_sale_price": { "value": 43743.57015967369 }
+    },
+    {
+      "order_items.created_week": { "value": "2024-03-18" },
+      "order_items.total_sale_price": { "value": 39726.64014363289 }
+    },
+    {
+      "order_items.created_week": { "value": "2024-03-25" },
+      "order_items.total_sale_price": { "value": 45381.03020477295 }
+    },
+    {
+      "order_items.created_week": { "value": "2024-04-01" },
+      "order_items.total_sale_price": { "value": 42859.76013171673 }
+    },
+    {
+      "order_items.created_week": { "value": "2024-04-08" },
+      "order_items.total_sale_price": { "value": 42961.31019115448 }
+    },
+    {
+      "order_items.created_week": { "value": "2024-04-15" },
+      "order_items.total_sale_price": { "value": 45390.05018091202 }
+    },
+    {
+      "order_items.created_week": { "value": "2024-04-22" },
+      "order_items.total_sale_price": { "value": 46888.71019887924 }
+    },
+    {
+      "order_items.created_week": { "value": "2024-04-29" },
+      "order_items.total_sale_price": { "value": 47262.29014444351 }
+    },
+    {
+      "order_items.created_week": { "value": "2024-05-06" },
+      "order_items.total_sale_price": { "value": 45218.9601688385 }
+    },
+    {
+      "order_items.created_week": { "value": "2024-05-13" },
+      "order_items.total_sale_price": { "value": 44908.69012236595 }
+    },
+    {
+      "order_items.created_week": { "value": "2024-05-20" },
+      "order_items.total_sale_price": { "value": 42554.23016655445 }
+    },
+    {
+      "order_items.created_week": { "value": "2024-05-27" },
+      "order_items.total_sale_price": { "value": 45875.41014790535 }
+    },
+    {
+      "order_items.created_week": { "value": "2024-06-03" },
+      "order_items.total_sale_price": { "value": 53758.23018360138 }
+    },
+    {
+      "order_items.created_week": { "value": "2024-06-10" },
+      "order_items.total_sale_price": { "value": 45587.38023376465 }
+    },
+    {
+      "order_items.created_week": { "value": "2024-06-17" },
+      "order_items.total_sale_price": { "value": 46776.97010087967 }
+    },
+    {
+      "order_items.created_week": { "value": "2024-06-24" },
+      "order_items.total_sale_price": { "value": 48492.63023388386 }
+    },
+    {
+      "order_items.created_week": { "value": "2024-07-01" },
+      "order_items.total_sale_price": { "value": 42820.2201869674 }
+    },
+    {
+      "order_items.created_week": { "value": "2024-07-08" },
+      "order_items.total_sale_price": { "value": 49767.960173010826 }
+    },
+    {
+      "order_items.created_week": { "value": "2024-07-15" },
+      "order_items.total_sale_price": { "value": 48015.98019647598 }
+    },
+    {
+      "order_items.created_week": { "value": "2024-07-22" },
+      "order_items.total_sale_price": { "value": 45617.82017660141 }
+    },
+    {
+      "order_items.created_week": { "value": "2024-07-29" },
+      "order_items.total_sale_price": { "value": 46792.49014234543 }
+    },
+    {
+      "order_items.created_week": { "value": "2024-08-05" },
+      "order_items.total_sale_price": { "value": 46831.99022758007 }
+    },
+    {
+      "order_items.created_week": { "value": "2024-08-12" },
+      "order_items.total_sale_price": { "value": 53678.50020170212 }
+    },
+    {
+      "order_items.created_week": { "value": "2024-08-19" },
+      "order_items.total_sale_price": { "value": 52917.51023161411 }
+    },
+    {
+      "order_items.created_week": { "value": "2024-08-26" },
+      "order_items.total_sale_price": { "value": 50193.970160484314 }
+    },
+    {
+      "order_items.created_week": { "value": "2024-09-02" },
+      "order_items.total_sale_price": { "value": 54361.31017410755 }
+    },
+    {
+      "order_items.created_week": { "value": "2024-09-09" },
+      "order_items.total_sale_price": { "value": 57917.3702082634 }
+    },
+    {
+      "order_items.created_week": { "value": "2024-09-16" },
+      "order_items.total_sale_price": { "value": 54842.49020373821 }
+    },
+    {
+      "order_items.created_week": { "value": "2024-09-23" },
+      "order_items.total_sale_price": { "value": 57146.88021993637 }
+    },
+    {
+      "order_items.created_week": { "value": "2024-09-30" },
+      "order_items.total_sale_price": { "value": 57735.4002610445 }
+    },
+    {
+      "order_items.created_week": { "value": "2024-10-07" },
+      "order_items.total_sale_price": { "value": 59615.8402929306 }
+    },
+    {
+      "order_items.created_week": { "value": "2024-10-14" },
+      "order_items.total_sale_price": { "value": 59998.51023006439 }
+    },
+    {
+      "order_items.created_week": { "value": "2024-10-21" },
+      "order_items.total_sale_price": { "value": 57104.87022304535 }
+    },
+    {
+      "order_items.created_week": { "value": "2024-10-28" },
+      "order_items.total_sale_price": { "value": 60766.14020442963 }
+    },
+    {
+      "order_items.created_week": { "value": "2024-11-04" },
+      "order_items.total_sale_price": { "value": 63506.08022522926 }
+    },
+    {
+      "order_items.created_week": { "value": "2024-11-11" },
+      "order_items.total_sale_price": { "value": 63190.66029167175 }
+    },
+    {
+      "order_items.created_week": { "value": "2024-11-18" },
+      "order_items.total_sale_price": { "value": 66264.5902121067 }
+    },
+    {
+      "order_items.created_week": { "value": "2024-11-25" },
+      "order_items.total_sale_price": { "value": 64925.84025120735 }
+    },
+    {
+      "order_items.created_week": { "value": "2024-12-02" },
+      "order_items.total_sale_price": { "value": 69692.5502730608 }
+    },
+    {
+      "order_items.created_week": { "value": "2024-12-09" },
+      "order_items.total_sale_price": { "value": 71538.4502735138 }
+    },
+    {
+      "order_items.created_week": { "value": "2024-12-16" },
+      "order_items.total_sale_price": { "value": 63320.1702337265 }
+    },
+    {
+      "order_items.created_week": { "value": "2024-12-23" },
+      "order_items.total_sale_price": { "value": 64341.93018293381 }
+    },
+    {
+      "order_items.created_week": { "value": "2024-12-30" },
+      "order_items.total_sale_price": { "value": 63918.630224466324 }
+    },
+    {
+      "order_items.created_week": { "value": "2025-01-06" },
+      "order_items.total_sale_price": { "value": 61042.02020740509 }
+    },
+    {
+      "order_items.created_week": { "value": "2025-01-13" },
+      "order_items.total_sale_price": { "value": 63515.79023051262 }
+    },
+    {
+      "order_items.created_week": { "value": "2025-01-20" },
+      "order_items.total_sale_price": { "value": 56345.890234947205 }
+    },
+    {
+      "order_items.created_week": { "value": "2025-01-27" },
+      "order_items.total_sale_price": { "value": 60395.25022494793 }
+    },
+    {
+      "order_items.created_week": { "value": "2025-02-03" },
+      "order_items.total_sale_price": { "value": 64485.270298957825 }
+    },
+    {
+      "order_items.created_week": { "value": "2025-02-10" },
+      "order_items.total_sale_price": { "value": 65296.4201900959 }
+    },
+    {
+      "order_items.created_week": { "value": "2025-02-17" },
+      "order_items.total_sale_price": { "value": 66349.39027392864 }
+    },
+    {
+      "order_items.created_week": { "value": "2025-02-24" },
+      "order_items.total_sale_price": { "value": 65866.6902897358 }
+    },
+    {
+      "order_items.created_week": { "value": "2025-03-03" },
+      "order_items.total_sale_price": { "value": 68675.76024341583 }
+    },
+    {
+      "order_items.created_week": { "value": "2025-03-10" },
+      "order_items.total_sale_price": { "value": 63404.130230784416 }
+    },
+    {
+      "order_items.created_week": { "value": "2025-03-17" },
+      "order_items.total_sale_price": { "value": 67058.70030283928 }
+    },
+    {
+      "order_items.created_week": { "value": "2025-03-24" },
+      "order_items.total_sale_price": { "value": 60214.04021906853 }
+    },
+    {
+      "order_items.created_week": { "value": "2025-03-31" },
+      "order_items.total_sale_price": { "value": 67922.43023252487 }
+    },
+    {
+      "order_items.created_week": { "value": "2025-04-07" },
+      "order_items.total_sale_price": { "value": 64956.680300593376 }
+    },
+    {
+      "order_items.created_week": { "value": "2025-04-14" },
+      "order_items.total_sale_price": { "value": 68644.28021740913 }
+    },
+    {
+      "order_items.created_week": { "value": "2025-04-21" },
+      "order_items.total_sale_price": { "value": 70649.94026708603 }
+    },
+    {
+      "order_items.created_week": { "value": "2025-04-28" },
+      "order_items.total_sale_price": { "value": 73909.07031726837 }
+    },
+    {
+      "order_items.created_week": { "value": "2025-05-05" },
+      "order_items.total_sale_price": { "value": 64490.920258402824 }
+    },
+    {
+      "order_items.created_week": { "value": "2025-05-12" },
+      "order_items.total_sale_price": { "value": 66514.61026871204 }
+    },
+    {
+      "order_items.created_week": { "value": "2025-05-19" },
+      "order_items.total_sale_price": { "value": 71607.87027692795 }
+    },
+    {
+      "order_items.created_week": { "value": "2025-05-26" },
+      "order_items.total_sale_price": { "value": 70964.84024608135 }
+    },
+    {
+      "order_items.created_week": { "value": "2025-06-02" },
+      "order_items.total_sale_price": { "value": 66244.53024959564 }
+    },
+    {
+      "order_items.created_week": { "value": "2025-06-09" },
+      "order_items.total_sale_price": { "value": 67427.77030014992 }
+    },
+    {
+      "order_items.created_week": { "value": "2025-06-16" },
+      "order_items.total_sale_price": { "value": 67045.25022006035 }
+    },
+    {
+      "order_items.created_week": { "value": "2025-06-23" },
+      "order_items.total_sale_price": { "value": 70213.5502986908 }
+    },
+    {
+      "order_items.created_week": { "value": "2025-06-30" },
+      "order_items.total_sale_price": { "value": 72271.67028963566 }
+    },
+    {
+      "order_items.created_week": { "value": "2025-07-07" },
+      "order_items.total_sale_price": { "value": 66827.20029187202 }
+    },
+    {
+      "order_items.created_week": { "value": "2025-07-14" },
+      "order_items.total_sale_price": { "value": 70150.31025362015 }
+    },
+    {
+      "order_items.created_week": { "value": "2025-07-21" },
+      "order_items.total_sale_price": { "value": 66657.37031292915 }
+    },
+    {
+      "order_items.created_week": { "value": "2025-07-28" },
+      "order_items.total_sale_price": { "value": 75411.80025756359 }
+    },
+    {
+      "order_items.created_week": { "value": "2025-08-04" },
+      "order_items.total_sale_price": { "value": 77989.52031433582 }
+    },
+    {
+      "order_items.created_week": { "value": "2025-08-11" },
+      "order_items.total_sale_price": { "value": 75189.91037940979 }
+    },
+    {
+      "order_items.created_week": { "value": "2025-08-18" },
+      "order_items.total_sale_price": { "value": 71586.21028161049 }
+    },
+    {
+      "order_items.created_week": { "value": "2025-08-25" },
+      "order_items.total_sale_price": { "value": 65475.52029442787 }
+    },
+    {
+      "order_items.created_week": { "value": "2025-09-01" },
+      "order_items.total_sale_price": { "value": 75598.23038887978 }
+    },
+    {
+      "order_items.created_week": { "value": "2025-09-08" },
+      "order_items.total_sale_price": { "value": 80341.65031576157 }
+    },
+    {
+      "order_items.created_week": { "value": "2025-09-15" },
+      "order_items.total_sale_price": { "value": 77490.29027342796 }
+    },
+    {
+      "order_items.created_week": { "value": "2025-09-22" },
+      "order_items.total_sale_price": { "value": 84792.75030136108 }
+    },
+    {
+      "order_items.created_week": { "value": "2025-09-29" },
+      "order_items.total_sale_price": { "value": 76279.48022651672 }
+    },
+    {
+      "order_items.created_week": { "value": "2025-10-06" },
+      "order_items.total_sale_price": { "value": 82567.44029068947 }
+    },
+    {
+      "order_items.created_week": { "value": "2025-10-13" },
+      "order_items.total_sale_price": { "value": 86317.1902359724 }
+    },
+    {
+      "order_items.created_week": { "value": "2025-10-20" },
+      "order_items.total_sale_price": { "value": 87162.7203155756 }
+    },
+    {
+      "order_items.created_week": { "value": "2025-10-27" },
+      "order_items.total_sale_price": { "value": 83433.6603269577 }
+    },
+    {
+      "order_items.created_week": { "value": "2025-11-03" },
+      "order_items.total_sale_price": { "value": 86808.94029307365 }
+    },
+    {
+      "order_items.created_week": { "value": "2025-11-10" },
+      "order_items.total_sale_price": { "value": 88339.89038348198 }
+    },
+    {
+      "order_items.created_week": { "value": "2025-11-17" },
+      "order_items.total_sale_price": { "value": 86451.9804366827 }
+    },
+    {
+      "order_items.created_week": { "value": "2025-11-24" },
+      "order_items.total_sale_price": { "value": 84682.64038074017 }
+    },
+    {
+      "order_items.created_week": { "value": "2025-12-01" },
+      "order_items.total_sale_price": { "value": 89578.26036989689 }
+    },
+    {
+      "order_items.created_week": { "value": "2025-12-08" },
+      "order_items.total_sale_price": { "value": 95604.78030109406 }
+    },
+    {
+      "order_items.created_week": { "value": "2025-12-15" },
+      "order_items.total_sale_price": { "value": 96869.79031968117 }
+    },
+    {
+      "order_items.created_week": { "value": "2025-12-22" },
+      "order_items.total_sale_price": { "value": 97018.34035754204 }
+    },
+    {
+      "order_items.created_week": { "value": "2025-12-29" },
+      "order_items.total_sale_price": { "value": 89344.03036165237 }
+    },
+    {
+      "order_items.created_week": { "value": "2026-01-05" },
+      "order_items.total_sale_price": { "value": 90640.19038593769 }
+    },
+    {
+      "order_items.created_week": { "value": "2026-01-12" },
+      "order_items.total_sale_price": { "value": 99393.44034862518 }
+    },
+    {
+      "order_items.created_week": { "value": "2026-01-19" },
+      "order_items.total_sale_price": { "value": 90467.44025468826 }
+    },
+    {
+      "order_items.created_week": { "value": "2026-01-26" },
+      "order_items.total_sale_price": { "value": 89349.02034235 }
+    },
+    {
+      "order_items.created_week": { "value": "2026-02-02" },
+      "order_items.total_sale_price": { "value": 99286.25041353703 }
+    },
+    {
+      "order_items.created_week": { "value": "2026-02-09" },
+      "order_items.total_sale_price": { "value": 97016.82035064697 }
+    },
+    {
+      "order_items.created_week": { "value": "2026-02-16" },
+      "order_items.total_sale_price": { "value": 98764.9903037548 }
+    },
+    {
+      "order_items.created_week": { "value": "2026-02-23" },
+      "order_items.total_sale_price": { "value": 96178.25035095215 }
+    },
+    {
+      "order_items.created_week": { "value": "2026-03-02" },
+      "order_items.total_sale_price": { "value": 96818.53033924103 }
+    },
+    {
+      "order_items.created_week": { "value": "2026-03-09" },
+      "order_items.total_sale_price": { "value": 93066.49033403397 }
+    },
+    {
+      "order_items.created_week": { "value": "2026-03-16" },
+      "order_items.total_sale_price": { "value": 98788.64037799835 }
+    },
+    {
+      "order_items.created_week": { "value": "2026-03-23" },
+      "order_items.total_sale_price": { "value": 99687.84039258957 }
+    },
+    {
+      "order_items.created_week": { "value": "2026-03-30" },
+      "order_items.total_sale_price": { "value": 98219.8503267765 }
+    },
+    {
+      "order_items.created_week": { "value": "2026-04-06" },
+      "order_items.total_sale_price": { "value": 96999.18039369583 }
+    },
+    {
+      "order_items.created_week": { "value": "2026-04-13" },
+      "order_items.total_sale_price": { "value": 95981.00044035912 }
+    },
+    {
+      "order_items.created_week": { "value": "2026-04-20" },
+      "order_items.total_sale_price": { "value": 106174.65039038658 }
+    },
+    {
+      "order_items.created_week": { "value": "2026-04-27" },
+      "order_items.total_sale_price": { "value": 105982.48033738136 }
+    },
+    {
+      "order_items.created_week": { "value": "2026-05-04" },
+      "order_items.total_sale_price": { "value": 100518.75039076805 }
+    },
+    {
+      "order_items.created_week": { "value": "2026-05-11" },
+      "order_items.total_sale_price": { "value": 100791.50030708313 }
+    },
+    {
+      "order_items.created_week": { "value": "2026-05-18" },
+      "order_items.total_sale_price": { "value": 103509.16035974026 }
+    },
+    {
+      "order_items.created_week": { "value": "2026-05-25" },
+      "order_items.total_sale_price": { "value": 98428.91036295891 }
+    },
+    {
+      "order_items.created_week": { "value": "2026-06-01" },
+      "order_items.total_sale_price": { "value": 101681.32038235664 }
+    },
+    {
+      "order_items.created_week": { "value": "2026-06-08" },
+      "order_items.total_sale_price": { "value": 100650.19037628174 }
+    },
+    {
+      "order_items.created_week": { "value": "2026-06-15" },
+      "order_items.total_sale_price": { "value": 100389.16034221649 }
+    },
+    {
+      "order_items.created_week": { "value": "2026-06-22" },
+      "order_items.total_sale_price": { "value": 25530.3300948143 }
+    }
+  ]
+}

--- a/tests/windowLookerTable.test.js
+++ b/tests/windowLookerTable.test.js
@@ -84,7 +84,7 @@ describe('window.looker.table global function', () => {
   });
 
   test('renders seamlessly with direct json_detail_lite_stream payload', () => {
-    const jsonDetailPayload = require('../tmp/example-json_detail_lite_stream.json');
+    const jsonDetailPayload = require('./example_json_detail_lite_stream.json');
     window.looker.table(container, jsonDetailPayload);
     expect(container.querySelector('#visContainer')).not.toBeNull();
     expect(container.querySelector('table')).not.toBeNull();

--- a/tests/windowLookerTable.test.js
+++ b/tests/windowLookerTable.test.js
@@ -1,0 +1,92 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import '../src/report_table';
+
+describe('window.looker.table global function', () => {
+  let container;
+
+  beforeEach(() => {
+    document.body.innerHTML = '<div id="vis-target" style="width: 800px; height: 600px;"></div>';
+    container = document.getElementById('vis-target');
+  });
+
+  test('exposes window.looker.table and renders visualization', () => {
+    expect(typeof window.looker.table).toBe('function');
+
+    const queryResponse = {
+      fields: {
+        dimensions: [{ name: 'category', label: 'Category' }],
+        measures: [{ name: 'revenue', label: 'Revenue' }],
+        pivots: []
+      }
+    };
+
+    const data = [
+      { 'category': { value: 'Widgets' }, 'revenue': { value: 100 } }
+    ];
+
+    window.looker.table(container, {
+      data,
+      queryResponse,
+      config: { theme: 'traditional' }
+    });
+
+    expect(container.querySelector('#visContainer')).not.toBeNull();
+  });
+
+  test('supports passing single options object containing element', () => {
+    const queryResponse = {
+      fields: {
+        dimensions: [{ name: 'category', label: 'Category' }],
+        measures: [{ name: 'revenue', label: 'Revenue' }],
+        pivots: []
+      }
+    };
+
+    const data = [
+      { 'category': { value: 'Gadgets' }, 'revenue': { value: 200 } }
+    ];
+
+    window.looker.table({
+      element: '#vis-target',
+      data,
+      queryResponse,
+      config: { theme: 'contemporary' }
+    });
+
+    expect(container.querySelector('#visContainer')).not.toBeNull();
+  });
+
+  test('returns asExcel() function that generates Excel data URL', () => {
+    const queryResponse = {
+      fields: {
+        dimensions: [{ name: 'category', label: 'Category' }],
+        measures: [{ name: 'revenue', label: 'Revenue' }],
+        pivots: []
+      }
+    };
+
+    const data = [
+      { 'category': { value: 'Widgets' }, 'revenue': { value: 100 } }
+    ];
+
+    const instance = window.looker.table(container, {
+      data,
+      queryResponse,
+      config: { theme: 'traditional' }
+    });
+
+    expect(typeof instance.asExcel).toBe('function');
+    const dataUrl = instance.asExcel();
+    expect(dataUrl).toContain('data:application/vnd.ms-excel');
+  });
+
+  test('renders seamlessly with direct json_detail_lite_stream payload', () => {
+    const jsonDetailPayload = require('../tmp/example-json_detail_lite_stream.json');
+    window.looker.table(container, jsonDetailPayload);
+    expect(container.querySelector('#visContainer')).not.toBeNull();
+    expect(container.querySelector('table')).not.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary of Changes
This PR introduces standalone embedding support for the Report Table custom visualization, enabling non-Looker web applications (and headless Node.js server-side tasks via JSDOM) to render custom tables and export Excel files directly using `window.looker.table()`.

---

## Key Improvements

### 1. Global Standalone API (`window.looker.table`)
Exposes `window.looker.table()` to render custom tables into any DOM element outside of Looker:
```javascript
const instance = window.looker.table('#table-container', { queryResponse, data, config });
```

### 2. Direct Looker API Payload Support (`json_detail` / `json_detail_lite_stream`)
Accepts raw Looker query API responses directly without requiring custom data converters. Automatically normalizes field definitions (`dimensions`/`measures` to `dimension_like`/`measure_like`) and safely handles null `totals_data` payloads.

### 3. Excel Export Instance Methods
`window.looker.table()` returns an instance object with dedicated Excel export handles:
- `instance.asExcel()`: Returns the generated `.xls` Data URL (`data:application/vnd.ms-excel,...`).
- `instance.downloadExcel(filename)`: Triggers a direct browser file download.

### 4. Non-Host Environment Resilience
Introduces safe fallback stubs for Looker host triggers (`trigger`, `clearErrors`, `addError`) to prevent `TypeError` exceptions when invoked outside Looker iframe contexts. Uses native `!el.hasChildNodes()` checks to avoid DOM property mutation.

---

## Documentation & Testing
- **Documentation**: Added comprehensive usage guide, options reference, and Node.js JSDOM integration examples in [`standalone.md`](standalone.md). Linked from [`README.md`](README.md).
- **Test Coverage**: Added Jest test suite in [`tests/windowLookerTable.test.js`](tests/windowLookerTable.test.js) verifying rendering, options passing, and Excel exports (all 34 tests passing).