### PR TITLE
feat: Add CSS class helpers for pivot column group targeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,45 @@ Please use [this example template](src/theme_custom_template.css) to help you ge
 }
 ```
 
+#### 3. Grouped & Pivoted Column Targeting
+```css
+/* Style alternating grouped/pivoted column groups (e.g. QTD vs YTD) */
+#reportTable td.pivot-group-even,
+#reportTable th.pivot-group-even {
+  background-color: #ececec;
+}
+#reportTable td.pivot-group-odd,
+#reportTable th.pivot-group-odd {
+  background-color: #ffffff;
+}
+
+/* Or target a specific pivot group index directly (e.g., pivot group 0) */
+#reportTable .pivot-group-0 {
+  border-left: 2px solid #006B9B;
+}
+```
+
+#### 4. Targeting the Last X Rows
+```css
+/* Highlight the last 4 rows in the table (e.g. summary / grand total rows) */
+#reportTable tbody tr:nth-last-child(-n+4) td {
+  background-color: #f0f0f0 !important;
+  font-weight: bold;
+}
+```
+
+#### 5. Alternating Row Shading (Zebra Striping)
+```css
+/* Apply alternating row backgrounds to body rows */
+#reportTable tbody tr:nth-child(even) td {
+  background-color: #f8f9fa;
+}
+#reportTable tbody tr:nth-child(odd) td {
+  background-color: #ffffff;
+}
+```
+
+
 ### Hosting Your Custom CSS Simple & Free
 
 To load external CSS into Looker, the stylesheet must be served over HTTPS with permissive **CORS** (`Access-Control-Allow-Origin: *`) and a `Content-Type: text/css` header. 

--- a/src/report_table.js
+++ b/src/report_table.js
@@ -398,6 +398,12 @@ const buildReportTable = function(config, dataTable, updateColumnOrder, updateCo
       .data(d => d).enter()
         .append('col')
         .attr('id', d => ['col',d.id].join('').replace('.', '') )
+        .attr('class', d => {
+          if (typeof d.pivot_index !== 'undefined') {
+            return `pivot-group-${d.pivot_index} pivot-group-${d.pivot_index % 2 === 0 ? 'even' : 'odd'}`
+          }
+          return ''
+        })
         .attr('span', 1)
         .style('width', d => {
           if (dataTable.minWidthForIndexColumns &&  d.type === 'index' && typeof columnTextWidths[d.id] !== 'undefined') {
@@ -466,6 +472,10 @@ const buildReportTable = function(config, dataTable, updateColumnOrder, updateCo
       .attr('class', d => {
         var classes = ['reportTable']
         if (typeof d.cell_style !== 'undefined') { classes = classes.concat(d.cell_style) }
+        if (d.column && typeof d.column.pivot_index !== 'undefined') {
+          classes.push(`pivot-group-${d.column.pivot_index}`)
+          classes.push(`pivot-group-${d.column.pivot_index % 2 === 0 ? 'even' : 'odd'}`)
+        }
         return classes.join(' ')
       })
       .style('text-align', d => d.align)
@@ -589,6 +599,11 @@ const buildReportTable = function(config, dataTable, updateColumnOrder, updateCo
         if (typeof d.value === 'object') { classes.push('cellSeries') }
         if (typeof d.align !== 'undefined') { classes.push(d.align) }
         if (typeof d.cell_style !== 'undefined') { classes = classes.concat(d.cell_style) }
+        const col = dataTable.columns.find(c => c.id === d.colid)
+        if (col && typeof col.pivot_index !== 'undefined') {
+          classes.push(`pivot-group-${col.pivot_index}`)
+          classes.push(`pivot-group-${col.pivot_index % 2 === 0 ? 'even' : 'odd'}`)
+        }
         return classes.join(' ')
       })
       .on('mouseover', d => {

--- a/src/report_table.js
+++ b/src/report_table.js
@@ -399,8 +399,9 @@ const buildReportTable = function(config, dataTable, updateColumnOrder, updateCo
         .append('col')
         .attr('id', d => ['col',d.id].join('').replace('.', '') )
         .attr('class', d => {
-          if (typeof d.pivot_index !== 'undefined') {
-            return `pivot-group-${d.pivot_index} pivot-group-${d.pivot_index % 2 === 0 ? 'even' : 'odd'}`
+          const col = dataTable.columns.find(c => c.id === d.id)
+          if (col && typeof col.pivot_index !== 'undefined') {
+            return `pivot-group-${col.pivot_index} pivot-group-${col.pivot_index % 2 === 0 ? 'even' : 'odd'}`
           }
           return ''
         })

--- a/src/vis_table_plugin.js
+++ b/src/vis_table_plugin.js
@@ -654,7 +654,7 @@ class VisPluginTableModel {
     
     // add measures, list of full objects
     if (this.hasPivots) {
-      this.pivot_values.forEach(pivot_value => {
+      this.pivot_values.forEach((pivot_value, p_idx) => {
         var isRowTotal = pivot_value.key === '$$$_row_total_$$$'
         this.measures.forEach((measure, m) => {
           // for pivoted measures, skip table calcs for row totals 
@@ -666,6 +666,7 @@ class VisPluginTableModel {
             column.pivoted = isRowTotal ? false : true
             column.isRowTotal = isRowTotal
             column.pivot_key = pivot_value.key
+            column.pivot_index = p_idx
             column.idx = col_idx
 
             var tempSort = []
@@ -1517,6 +1518,10 @@ class VisPluginTableModel {
           subtotalColumn.pivoted = true
           subtotalColumn.subtotal = true
           subtotalColumn.pivot_key = [pivot, '$$$_subtotal_$$$'].join('|')
+          const matchPivotValue = this.pivot_values.find(pv => pv.data[pivot_dimension] === pivot)
+          if (matchPivotValue) {
+            subtotalColumn.pivot_index = this.pivot_values.indexOf(matchPivotValue)
+          }
           subtotalColumn.subtotal_data = {
             pivot: pivot,
             measure_idx: m,

--- a/src/vis_table_plugin.js
+++ b/src/vis_table_plugin.js
@@ -666,7 +666,7 @@ class VisPluginTableModel {
             column.pivoted = isRowTotal ? false : true
             column.isRowTotal = isRowTotal
             column.pivot_key = pivot_value.key
-            column.pivot_index = p_idx
+            column.pivot_index = isRowTotal ? undefined : p_idx
             column.idx = col_idx
 
             var tempSort = []
@@ -1518,9 +1518,9 @@ class VisPluginTableModel {
           subtotalColumn.pivoted = true
           subtotalColumn.subtotal = true
           subtotalColumn.pivot_key = [pivot, '$$$_subtotal_$$$'].join('|')
-          const matchPivotValue = this.pivot_values.find(pv => pv.data[pivot_dimension] === pivot)
-          if (matchPivotValue) {
-            subtotalColumn.pivot_index = this.pivot_values.indexOf(matchPivotValue)
+          const matchPivotIndex = this.pivot_values.findIndex(pv => pv.data[pivot_dimension] === pivot)
+          if (matchPivotIndex !== -1) {
+            subtotalColumn.pivot_index = matchPivotIndex
           }
           subtotalColumn.subtotal_data = {
             pivot: pivot,


### PR DESCRIPTION
Fixes #18

## Summary
Adds CSS class helpers (`.pivot-group-<N>`, `.pivot-group-even`, `.pivot-group-odd`) to table column definitions (`<col>`), headers (`<th>`), and data cells (`<td>`) when table data is pivoted. This enables custom theme stylesheets to easily target, style, or alternate shading across pivot column groups.

## Key Changes
- **Model Enrichment (`src/vis_table_plugin.js`)**: Tracks `pivot_index` on `Column` models for pivoted measures and derived column subtotals.
- **Class Injection (`src/report_table.js`)**: Emits `.pivot-group-<N>` and `.pivot-group-even`/`.pivot-group-odd` on `<col>`, `<th>`, and `<td>` elements based on column pivot index.
- **Documentation (`README.md`)**: Added custom styling documentation and code snippets for pivot group targeting, last X row styling, and zebra striping.