### PR TITLE
Bryan/valign2

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,15 @@ Please use [this example template](src/theme_custom_template.css) to help you ge
 }
 ```
 
+#### 6. Top-Aligning Table Cell Content
+```css
+/* Align table header and data cell text to the top across all cells */
+.reportTable th,
+.reportTable td {
+  vertical-align: top;
+}
+```
+
 
 ### Hosting Your Custom CSS Simple & Free
 

--- a/src/download_link.js
+++ b/src/download_link.js
@@ -104,6 +104,9 @@ export async function downloadTableAsExcel(targetElement) {
       ) {
         element.style["text-decoration"] = "underline";
       }
+      if (key === "vertical-align") {
+        element.setAttribute("valign", computedStyle.getPropertyValue(key));
+      }
     }
   };
   

--- a/src/theme_contemporary.css
+++ b/src/theme_contemporary.css
@@ -52,13 +52,14 @@
 }
 
 table.reportTable th {
+  vertical-align: top;
   border: 1px solid #CCCCCC; 
   border-bottom: 1px solid #000000 !important;
   padding: 5px;
 }
 
 table.reportTable td {
-  vertical-align: super;
+  vertical-align: top;
   padding: 5px;
   border: 1px solid #CCCCCC; 
   border-collapse: collapse;
@@ -79,7 +80,7 @@ table.reportTable td {
 }
 
 .rowCell {
-  vertical-align: super;
+  vertical-align: top;
   padding-left: 5px;
 }
 

--- a/src/theme_custom_template.css
+++ b/src/theme_custom_template.css
@@ -66,6 +66,7 @@
 }
 
 .reportTable th {
+  vertical-align: top;
   color: #000000;
   background-color: var(--table-header-bg);
   border: 1px solid #CCCCCC; 
@@ -80,7 +81,7 @@
 
 .reportTable td {
   color: #000000;
-  vertical-align: super;
+  vertical-align: top;
   padding: 5px;
   background-color: var(--table-bg);
   border: 1px solid #CCCCCC; 

--- a/src/theme_looker.css
+++ b/src/theme_looker.css
@@ -54,6 +54,7 @@
 }
 
 th.headerCell {
+  vertical-align: top;
   background-color: #ccd8e4;
   padding: 5px;
   border-bottom: 1px solid #BDC3C7;
@@ -103,7 +104,7 @@ th.headerCell {
 } */
 
 .rowCell {
-  vertical-align: super;
+  vertical-align: top;
   padding-left: 5px;
   border-bottom: 1px solid #BDC3C7; 
 }

--- a/src/theme_traditional.css
+++ b/src/theme_traditional.css
@@ -52,6 +52,7 @@
 }
 
 th.headerCell {
+  vertical-align: top;
   border-bottom: 1px solid #000000 !important;
   font-weight: bold;
   padding: 5px;
@@ -76,7 +77,7 @@ th.headerCell {
 }
 
 .rowCell {
-  vertical-align: super;
+  vertical-align: top;
   padding-left: 5px;
 }
 

--- a/src/vis_table_plugin.js
+++ b/src/vis_table_plugin.js
@@ -1366,7 +1366,7 @@ class VisPluginTableModel {
           var group = []
           for (var g = 0; g < depth; g++) {
             var dim = this.dimensions[g].name
-            group.push(row.data[dim].value)
+            group.push(row.data[dim]?.value)
           }
           var groupKey = group.join('|')
           var groupIdx = groupMap.get(groupKey)

--- a/src/vis_table_plugin.js
+++ b/src/vis_table_plugin.js
@@ -1358,8 +1358,9 @@ class VisPluginTableModel {
     depths.forEach((depth, depthIndex) => {
       this.subtotalRows[depthIndex] = []
       // BUILD GROUPINGS / SORT VALUES
+      // groupMap ensures non-contiguous rows (e.g. sorted by measure) share a single subtotal group
       var subTotalGroups = []
-      var latest_group = []
+      var groupMap = new Map()
       this.data.forEach((row, i) => {
         if (row.type === 'line_item') {
           var group = []
@@ -1367,13 +1368,16 @@ class VisPluginTableModel {
             var dim = this.dimensions[g].name
             group.push(row.data[dim].value)
           }
-          if (group.join('|') !== latest_group.join('|')) {
+          var groupKey = group.join('|')
+          var groupIdx = groupMap.get(groupKey)
+          if (groupIdx === undefined) {
+            groupIdx = subTotalGroups.length
             subTotalGroups.push(group)
-            latest_group = group
+            groupMap.set(groupKey, groupIdx)
           }
           var subSortObj = row.sort.find(s => s.name === 'subtotal_' + depthIndex);
           if (subSortObj) {
-            subSortObj.value = subTotalGroups.length - 1;
+            subSortObj.value = groupIdx;
           }
         }
 
@@ -1884,9 +1888,10 @@ class VisPluginTableModel {
       'jan': 1, 'feb': 2, 'mar': 3, 'apr': 4, 'may': 5, 'jun': 6,
       'jul': 7, 'aug': 8, 'sep': 9, 'oct': 10, 'nov': 11, 'dec': 12
     }
-    if (this.clientSorts && this.clientSorts.length > 0) {
-      for (var c = 0; c < this.clientSorts.length; c++) {
-        var sortObj = this.clientSorts[c]
+    const activeSorts = this.getActiveSorts ? this.getActiveSorts() : (this.clientSorts || [])
+    if (activeSorts && activeSorts.length > 0) {
+      for (var c = 0; c < activeSorts.length; c++) {
+        var sortObj = activeSorts[c]
         var cellA = a.data[sortObj.name]
         var cellB = b.data[sortObj.name]
 
@@ -1937,7 +1942,8 @@ class VisPluginTableModel {
         var subA = a.sort.find(s => s.name === pName) ? a.sort.find(s => s.name === pName).value : 0
         var subB = b.sort && b.sort.find(s => s.name === pName) ? b.sort.find(s => s.name === pName).value : 0
         if (subA !== subB) {
-          if (dataTable.clientSorts && dataTable.clientSorts.length > 0) {
+          const activeSorts = dataTable.getActiveSorts ? dataTable.getActiveSorts() : (dataTable.clientSorts || []);
+          if (activeSorts && activeSorts.length > 0) {
             const subRowA = dataTable.subtotalRows && dataTable.subtotalRows[k] ? dataTable.subtotalRows[k][subA] : null
             const subRowB = dataTable.subtotalRows && dataTable.subtotalRows[k] ? dataTable.subtotalRows[k][subB] : null
             if (subRowA && subRowB) {
@@ -1957,7 +1963,8 @@ class VisPluginTableModel {
         return origA - origB
       }
 
-      if (dataTable.clientSorts && dataTable.clientSorts.length > 0) {
+      const activeSorts = dataTable.getActiveSorts ? dataTable.getActiveSorts() : (dataTable.clientSorts || []);
+      if (activeSorts && activeSorts.length > 0) {
         const cmp = dataTable.compareRowsByClientSorts(a, b)
         if (cmp !== 0) {
           return cmp

--- a/tests/subtotals.test.js
+++ b/tests/subtotals.test.js
@@ -205,6 +205,7 @@ describe('Subtotals option bug reproduction', () => {
     expect(subtotalRows.map(r => r.data['history.created_month'].value)).toEqual(['France', 'UK']);
 
     const franceSubtotal = subtotalRows.find(r => r.data['history.created_month'].value === 'France');
+    expect(franceSubtotal).toBeDefined();
     expect(franceSubtotal.data['history.count'].value).toBe(511);
   });
 });

--- a/tests/subtotals.test.js
+++ b/tests/subtotals.test.js
@@ -163,5 +163,52 @@ describe('Subtotals option bug reproduction', () => {
     expect(totalRow.data['history.category'].colspan).toBe(-1);
     expect(totalRow.data['history.status'].colspan).toBe(1);
   });
+
+  it('should maintain single subtotal per group when rows are interleaved by measure sort', () => {
+    const { rows, metadata } = parseJsonBi(fixtures.history_created_month, [{ name: 'history.count', desc: true }]);
+    
+    delete metadata.pivots;
+    metadata.fields.pivots = [];
+    metadata.fields.dimension_like.push({
+      name: 'history.category',
+      type: 'string',
+      label: 'History Category',
+      view: 'history',
+      category: 'dimension'
+    });
+
+    const interleavedRows = [
+      {
+        'history.created_month': { value: 'France' },
+        'history.category': { value: 'Womens' },
+        'history.count': { value: 272 }
+      },
+      {
+        'history.created_month': { value: 'UK' },
+        'history.category': { value: 'Mens' },
+        'history.count': { value: 245 }
+      },
+      {
+        'history.created_month': { value: 'France' },
+        'history.category': { value: 'Mens' },
+        'history.count': { value: 239 }
+      }
+    ];
+
+    const model = new VisPluginTableModel(interleavedRows, metadata, {
+      rowSubtotals: true,
+      subtotalDepth: '1'
+    });
+
+    const subtotalRows = model.data.filter(r => r.type === 'subtotal');
+    expect(subtotalRows.length).toBe(2);
+    expect(subtotalRows.map(r => r.data['history.created_month'].value)).toEqual(['France', 'UK']);
+
+    const franceSubtotal = subtotalRows.find(r => r.data['history.created_month'].value === 'France');
+    expect(franceSubtotal.data['history.count'].value).toBe(511);
+  });
 });
+
+
+
 


### PR DESCRIPTION
Summary
This PR addresses subtotal grouping bugs during measure sorts and standardizes table cell vertical alignment across all themes and exports.

Fixes https://github.com/lkrdev/viz-report-table-marketplace2/issues/20 Fixes https://github.com/lkrdev/viz-report-table-marketplace2/issues/21

Key Changes
Subtotal Grouping Fix:

Updated VisPluginTableModel (src/report_table.js) to index subtotal groups using a group key map (groupMap) rather than assuming contiguous subtotal rows when rows are interleaved due to active client/measure sorts.
Refactored sorting helpers (getActiveSorts) to ensure client sorts are respected consistently when building subtotal rows.
Added unit test coverage in tests/subtotals.test.js verifying single subtotal calculation and proper grouping for interleaved rows.
Top-Alignment & Export Preservation:

Changed default vertical-align from super to top across all default themes (theme_contemporary.css, theme_custom_template.css, theme_looker.css, theme_traditional.css).
Enhanced src/download_link.js to set the HTML valign attribute on exported elements, preserving top alignment when exporting tables to Excel and Google Sheets.
Added CSS usage examples for top-aligning table cell content in README.md.
Code Quality & Skill Docs:

Applied pivot index and column group class updates from code review.
Added agent skill documentation for Looker dashboard development.
Verification
Ran full test suite (npm test), all 37 unit tests across 6 test suites passed.