### PR TITLE
feat: add 'Subtotals on Top' option and CSS border styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ A table dedicated to single-page, enterprise summary reports. Useful for PDF exp
 
 ## Recent Updates
 
+- Added a "Subtotals on Top" option to position row subtotals above line items at the top of their respective groups.
 - Added an option to freeze the first X columns during horizontal scrolling (fully compatible with transposed tables).
 - Added support for dynamic field labels in Looker (such as LookML's `label_from_parameter` or Liquid conditional logic).
 
@@ -223,6 +224,19 @@ Please use [this example template](src/theme_custom_template.css) to help you ge
 .reportTable th,
 .reportTable td {
   vertical-align: top;
+}
+```
+
+#### 7. Targeting Flipped Subtotals (Subtotals on Top)
+
+> [!NOTE]
+> When the **Subtotals on Top** option is enabled, `.subtotal-top` and `.subtotals-on-top` classes are automatically applied to `#reportTable`, subtotal rows (`<tr>`), and subtotal cells (`<td>`).
+
+```css
+/* Style flipped subtotal rows specifically when "Subtotals on Top" is enabled */
+#reportTable tr.subtotal-top td {
+  background-color: #e3f2fd !important;
+  font-weight: bold;
 }
 ```
 

--- a/src/report_table.js
+++ b/src/report_table.js
@@ -327,7 +327,7 @@ const buildReportTable = function(config, dataTable, updateColumnOrder, updateCo
     var table = d3.select('#visContainer')
       .append('table')
         .attr('id', 'reportTable')
-        .attr('class', 'reportTable')
+        .attr('class', (dataTable.subtotalsOnTop || config.subtotalsOnTop || config.subtotalOnTop) ? 'reportTable subtotals-on-top' : 'reportTable')
         .style('opacity', 0)
 
     var drag = d3.drag()
@@ -514,6 +514,9 @@ const buildReportTable = function(config, dataTable, updateColumnOrder, updateCo
         .append('tr')
         .attr('class', row => {
             let classes = row.type;
+            if (row.type === 'subtotal' && (dataTable.subtotalsOnTop || config.subtotalsOnTop || config.subtotalOnTop)) {
+                classes += ' subtotal-top subtotals-on-top';
+            }
             const rowPath = row.type === 'subtotal' ? String(row.id).substring(9) : String(row.id);
             if (config.startFolded) {
                 const savedUnfolded = config.expandSubtotals ? config.expandSubtotals.split(',') : [];
@@ -600,6 +603,10 @@ const buildReportTable = function(config, dataTable, updateColumnOrder, updateCo
         if (typeof d.value === 'object') { classes.push('cellSeries') }
         if (typeof d.align !== 'undefined') { classes.push(d.align) }
         if (typeof d.cell_style !== 'undefined') { classes = classes.concat(d.cell_style) }
+        if (d.cell_style && d.cell_style.includes('subtotal') && (dataTable.subtotalsOnTop || config.subtotalsOnTop || config.subtotalOnTop)) {
+          if (!classes.includes('subtotal-top')) classes.push('subtotal-top')
+          if (!classes.includes('subtotals-on-top')) classes.push('subtotals-on-top')
+        }
         const col = dataTable.columns.find(c => c.id === d.colid)
         if (col && typeof col.pivot_index !== 'undefined') {
           classes.push(`pivot-group-${col.pivot_index}`)

--- a/src/report_table.js
+++ b/src/report_table.js
@@ -327,7 +327,7 @@ const buildReportTable = function(config, dataTable, updateColumnOrder, updateCo
     var table = d3.select('#visContainer')
       .append('table')
         .attr('id', 'reportTable')
-        .attr('class', (dataTable.subtotalsOnTop || config.subtotalsOnTop || config.subtotalOnTop) ? 'reportTable subtotals-on-top' : 'reportTable')
+        .attr('class', dataTable.subtotalsOnTop ? 'reportTable subtotals-on-top' : 'reportTable')
         .style('opacity', 0)
 
     var drag = d3.drag()
@@ -514,7 +514,7 @@ const buildReportTable = function(config, dataTable, updateColumnOrder, updateCo
         .append('tr')
         .attr('class', row => {
             let classes = row.type;
-            if (row.type === 'subtotal' && (dataTable.subtotalsOnTop || config.subtotalsOnTop || config.subtotalOnTop)) {
+            if (row.type === 'subtotal' && dataTable.subtotalsOnTop) {
                 classes += ' subtotal-top subtotals-on-top';
             }
             const rowPath = row.type === 'subtotal' ? String(row.id).substring(9) : String(row.id);
@@ -603,7 +603,7 @@ const buildReportTable = function(config, dataTable, updateColumnOrder, updateCo
         if (typeof d.value === 'object') { classes.push('cellSeries') }
         if (typeof d.align !== 'undefined') { classes.push(d.align) }
         if (typeof d.cell_style !== 'undefined') { classes = classes.concat(d.cell_style) }
-        if (d.cell_style && d.cell_style.includes('subtotal') && (dataTable.subtotalsOnTop || config.subtotalsOnTop || config.subtotalOnTop)) {
+        if (d.cell_style && d.cell_style.includes('subtotal') && dataTable.subtotalsOnTop) {
           if (!classes.includes('subtotal-top')) classes.push('subtotal-top')
           if (!classes.includes('subtotals-on-top')) classes.push('subtotals-on-top')
         }

--- a/src/theme_contemporary.css
+++ b/src/theme_contemporary.css
@@ -122,6 +122,15 @@ tr.total + tr.subtotal > td.subtotal {
   border-bottom: 2px solid #000000 !important;
 }
 
+.subtotals-on-top tr.subtotal + tr.subtotal > td.subtotal {
+  border-top: none !important;
+  border-bottom: none !important;
+}
+
+.subtotals-on-top tr.line_item + tr.subtotal > td.subtotal {
+  border-top: 2px solid #000000 !important;
+}
+
 .total.transposed {
   border-top: 0px !important;
   background: #D3D3D3;

--- a/src/theme_custom_template.css
+++ b/src/theme_custom_template.css
@@ -134,6 +134,15 @@
 
 }
 
+.subtotals-on-top tr.subtotal + tr.subtotal > td.subtotal {
+  border-top: none !important;
+  border-bottom: none !important;
+}
+
+.subtotals-on-top tr.line_item + tr.subtotal > td.subtotal {
+  border-top: 2px solid #000000 !important;
+}
+
 .total.transposed {
   border-top: 0px !important;
   background: var(--table-subtotal-bg);

--- a/src/theme_custom_template.css
+++ b/src/theme_custom_template.css
@@ -134,6 +134,9 @@
 
 }
 
+/* Styling for flipped subtotals (when "Subtotals on Top" is enabled) */
+/* .subtotal-top { font-weight: bold; } */
+
 .subtotals-on-top tr.subtotal + tr.subtotal > td.subtotal {
   border-top: none !important;
   border-bottom: none !important;

--- a/src/theme_looker.css
+++ b/src/theme_looker.css
@@ -187,6 +187,15 @@ tr.total + tr.subtotal > td.subtotal {
   border-bottom: 2px solid #696969 !important;
 }
 
+.subtotals-on-top tr.subtotal + tr.subtotal > td.subtotal {
+  border-top: none !important;
+  border-bottom: none !important;
+}
+
+.subtotals-on-top tr.line_item + tr.subtotal > td.subtotal {
+  border-top: 2px solid #696969 !important;
+}
+
 .total.transposed {
   border-top: 0px !important;
   background: #D3D3D3;

--- a/src/theme_traditional.css
+++ b/src/theme_traditional.css
@@ -126,6 +126,15 @@ tr.total + tr.subtotal > td.subtotal {
   border-bottom: 2px solid #000000 !important;
 }
 
+.subtotals-on-top tr.subtotal + tr.subtotal > td.subtotal {
+  border-top: none !important;
+  border-bottom: none !important;
+}
+
+.subtotals-on-top tr.line_item + tr.subtotal > td.subtotal {
+  border-top: 2px solid #000000 !important;
+}
+
 .total.transposed {
   border-top: 0px !important;
 }

--- a/src/vis_table_plugin.js
+++ b/src/vis_table_plugin.js
@@ -184,6 +184,13 @@ const tableModelCoreOptions = {
     default: false,
     order: 11
   },
+  subtotalsOnTop: {
+    section: "Table",
+    type: "boolean",
+    label: "Subtotals on Top",
+    default: false,
+    order: 12,
+  },
   indexColumn: {
     section: "Dimensions",
     type: "boolean",
@@ -287,6 +294,7 @@ class VisPluginTableModel {
     this.useShortName = config.useShortName || false
     this.useViewName = config.useViewName || false
     this.addRowSubtotals = config.rowSubtotals || false
+    this.subtotalsOnTop = config.subtotalsOnTop || config.subtotalOnTop || false
     this.addSubtotalDepth = config.subtotalDepth
     this.addColSubtotals = config.colSubtotals || false
     this.spanRows = false || config.spanRows
@@ -1298,7 +1306,7 @@ class VisPluginTableModel {
         var neighbour_value = l > 0 ? leaves[l - 1].data[tier.name].value : null
 
         // Match: mark invisible (span_value = -1). Increment the span_tracker.
-        if (l > 0 && this_tier_value === neighbour_value) {
+        if (l > 0 && leaves[l - 1].type === 'line_item' && this_tier_value === neighbour_value) {
           leaf.data[tier.name].rowspan = -1
           leaf.data[tier.name].colspan = -1
           span_tracker[tier.name] += 1
@@ -1397,6 +1405,7 @@ class VisPluginTableModel {
         if (column.modelField.type === 'dimension') {
           const { colspan, rowspan } = dimColspans[column.id] || { colspan: -1, rowspan: -1 };
           var cell_style = column.modelField.is_numeric ? ['total', 'subtotal', 'numeric', 'dimension'] : ['total', 'subtotal', 'nonNumeric', 'dimension']
+          if (this.subtotalsOnTop) { cell_style.push('subtotal-top', 'subtotals-on-top') }
           var cell = new DataCell({ 
             value: '',
             'cell_style': cell_style, 
@@ -1420,6 +1429,7 @@ class VisPluginTableModel {
 
         if (column.modelField.type === 'measure') {
           var cell_style = column.modelField.is_numeric ? ['total', 'subtotal', 'numeric', 'measure'] : ['total', 'subtotal', 'nonNumeric', 'measure']
+          if (this.subtotalsOnTop) { cell_style.push('subtotal-top', 'subtotals-on-top') }
           var align = column.modelField.is_numeric ? 'right' : 'left'
           if (Object.entries(this.subtotals_data).length > 0 && !subtotalRow.id.startsWith('Subtotal|Others')) { // if subtotals already provided in Looker's queryResponse
             var cell = new DataCell({ 
@@ -1481,10 +1491,10 @@ class VisPluginTableModel {
         } else if (d === depthIndex) {
           subtotalRow.sort.push({name: 'subtotal_' + d, value: s});
         } else {
-          subtotalRow.sort.push({name: 'subtotal_' + d, value: 9999});
+          subtotalRow.sort.push({name: 'subtotal_' + d, value: this.subtotalsOnTop ? -1 : 9999});
         }
       }
-      subtotalRow.sort.push({name: 'original_row', value: 9999});
+      subtotalRow.sort.push({name: 'original_row', value: this.subtotalsOnTop ? -1 : 9999});
       this.data.push(subtotalRow)
       this.subtotalRows[depthIndex][s] = subtotalRow
     })

--- a/tests/subtotals.test.js
+++ b/tests/subtotals.test.js
@@ -208,7 +208,80 @@ describe('Subtotals option bug reproduction', () => {
     expect(franceSubtotal).toBeDefined();
     expect(franceSubtotal.data['history.count'].value).toBe(511);
   });
+
+  it('should position subtotals on top when subtotalsOnTop option is true', () => {
+    const { rows, metadata } = parseJsonBi(fixtures.history_created_month);
+    
+    metadata.fields.dimension_like.push({
+      name: 'history.category',
+      type: 'string',
+      label: 'History Category',
+      view: 'history',
+      category: 'dimension'
+    });
+    metadata.fields.dimension_like.push({
+      name: 'history.status',
+      type: 'string',
+      label: 'History Status',
+      view: 'history',
+      category: 'dimension'
+    });
+
+    const multiLevelRows = [
+      {
+        'history.created_month': { value: 'France' },
+        'history.category': { value: 'Europe' },
+        'history.status': { value: 'Accessories' },
+        'history.count': { value: 100 }
+      },
+      {
+        'history.created_month': { value: 'France' },
+        'history.category': { value: 'Europe' },
+        'history.status': { value: 'Clothing' },
+        'history.count': { value: 200 }
+      }
+    ];
+
+    const modelBottom = new VisPluginTableModel(multiLevelRows, metadata, {
+      rowSubtotals: true,
+      subtotalDepth: '(all)',
+      subtotalsOnTop: false
+    });
+
+    const labelsBottom = modelBottom.data.map(r => {
+      if (r.type === 'subtotal') return r.id;
+      return `${r.data['history.created_month']?.value} | ${r.data['history.category']?.value} | ${r.data['history.status']?.value}`;
+    });
+
+    // Expect line items first, then subtotal depth 1, then subtotal depth 0
+    expect(labelsBottom).toEqual([
+      'France | Europe | Accessories',
+      'France | Europe | Clothing',
+      'Subtotal|France|Europe',
+      'Subtotal|France'
+    ]);
+
+    const modelTop = new VisPluginTableModel(multiLevelRows, metadata, {
+      rowSubtotals: true,
+      subtotalDepth: '(all)',
+      subtotalsOnTop: true
+    });
+
+    const labelsTop = modelTop.data.map(r => {
+      if (r.type === 'subtotal') return r.id;
+      return `${r.data['history.created_month']?.value} | ${r.data['history.category']?.value} | ${r.data['history.status']?.value}`;
+    });
+
+    // Expect subtotal depth 0 (France), subtotal depth 1 (France|Europe), then line items
+    expect(labelsTop).toEqual([
+      'Subtotal|France',
+      'Subtotal|France|Europe',
+      'France | Europe | Accessories',
+      'France | Europe | Clothing'
+    ]);
+  });
 });
+
 
 
 


### PR DESCRIPTION
### Description
Adds a new visualization option `subtotalsOnTop` ("Subtotals on Top") to allow presenting row subtotals at the top of their respective groups instead of the bottom.

### Key Changes
- **Option Registration**: Added `subtotalsOnTop` boolean option in `tableModelCoreOptions` under Table section.
- **Sorting Logic**: Updated subtotal row sort keys so top-level subtotals sort above child subtotals and line items when `subtotalsOnTop` is enabled.
- **Row Spanning**: Prevented line item rowspan merging with subtotal rows
- **CSS & Classes**: Added `.subtotals-on-top` and `.subtotal-top` classes to table, rows, and cells for explicit styling, and added section divider borders while avoiding double-underline stacking.
- **Tests**: Added unit tests in `tests/subtotals.test.js`.